### PR TITLE
Add Alice Colours

### DIFF
--- a/AliceCore.install
+++ b/AliceCore.install
@@ -1,6 +1,6 @@
 {
 	"name": "AliceCore",
-	"version": "1.2.16",
+	"version": "1.2.17",
 	"icon": "fab fa-creative-commons-by",
 	"category": "alice",
 	"author": "ProjectAlice",

--- a/dialogTemplate/de.json
+++ b/dialogTemplate/de.json
@@ -27353,6 +27353,812 @@
 					"value": "zylinder"
 				}
 			]
+		},
+		{
+			"name": "Alice/Colors",
+			"matchingStrictness": null,
+			"automaticallyExtensible": true,
+			"useSynonyms": true,
+			"values": [
+				{
+					"value": "239, 222, 205",
+					"synonyms": [
+						"Almond"
+					]
+				},
+				{
+					"value": "205, 149, 117",
+					"synonyms": [
+						"Antique Brass"
+					]
+				},
+				{
+					"value": "253, 217, 181",
+					"synonyms": [
+						"Apricot"
+					]
+				},
+				{
+					"value": "120, 219, 226",
+					"synonyms": [
+						"Aquamarine"
+					]
+				},
+				{
+					"value": "135, 169, 107",
+					"synonyms": [
+						"Asparagus"
+					]
+				},
+				{
+					"value": "255, 164, 116",
+					"synonyms": [
+						"Atomic Tangerine"
+					]
+				},
+				{
+					"value": "250, 231, 181",
+					"synonyms": [
+						"Banana Mania"
+					]
+				},
+				{
+					"value": "159, 129, 112",
+					"synonyms": [
+						"Beaver"
+					]
+				},
+				{
+					"value": "253, 124, 110",
+					"synonyms": [
+						"Bittersweet"
+					]
+				},
+				{
+					"value": "0,0,0",
+					"synonyms": [
+						"Black"
+					]
+				},
+				{
+					"value": "172, 229, 238",
+					"synonyms": [
+						"Blizzard Blue"
+					]
+				},
+				{
+					"value": "31, 117, 254",
+					"synonyms": [
+						"Blue"
+					]
+				},
+				{
+					"value": "162, 162, 208",
+					"synonyms": [
+						"Blue Bell"
+					]
+				},
+				{
+					"value": "102, 153, 204",
+					"synonyms": [
+						"Blue Gray"
+					]
+				},
+				{
+					"value": "13, 152, 186",
+					"synonyms": [
+						"Blue Green"
+					]
+				},
+				{
+					"value": "115, 102, 189",
+					"synonyms": [
+						"Blue Violet"
+					]
+				},
+				{
+					"value": "222, 93, 131",
+					"synonyms": [
+						"Blush"
+					]
+				},
+				{
+					"value": "203, 65, 84",
+					"synonyms": [
+						"Brick Red"
+					]
+				},
+				{
+					"value": "180, 103, 77",
+					"synonyms": [
+						"Brown"
+					]
+				},
+				{
+					"value": "255, 127, 73",
+					"synonyms": [
+						"Burnt Orange"
+					]
+				},
+				{
+					"value": "234, 126, 93",
+					"synonyms": [
+						"Burnt Sienna"
+					]
+				},
+				{
+					"value": "176, 183, 198",
+					"synonyms": [
+						"Cadet Blue"
+					]
+				},
+				{
+					"value": "255, 255, 153",
+					"synonyms": [
+						"Canary"
+					]
+				},
+				{
+					"value": "28, 211, 162",
+					"synonyms": [
+						"Caribbean Green"
+					]
+				},
+				{
+					"value": "255, 170, 204",
+					"synonyms": [
+						"Carnation Pink"
+					]
+				},
+				{
+					"value": "221, 68, 146",
+					"synonyms": [
+						"Cerise"
+					]
+				},
+				{
+					"value": "29, 172, 214",
+					"synonyms": [
+						"Cerulean"
+					]
+				},
+				{
+					"value": "188, 93, 88",
+					"synonyms": [
+						"Chestnut"
+					]
+				},
+				{
+					"value": "221, 148, 117",
+					"synonyms": [
+						"Copper"
+					]
+				},
+				{
+					"value": "154, 206, 235",
+					"synonyms": [
+						"Cornflower"
+					]
+				},
+				{
+					"value": "255, 188, 217",
+					"synonyms": [
+						"Cotton Candy"
+					]
+				},
+				{
+					"value": "253, 219, 109",
+					"synonyms": [
+						"Dandelion"
+					]
+				},
+				{
+					"value": "43, 108, 196",
+					"synonyms": [
+						"Denim"
+					]
+				},
+				{
+					"value": "239, 205, 184",
+					"synonyms": [
+						"Desert Sand"
+					]
+				},
+				{
+					"value": "110, 81, 96",
+					"synonyms": [
+						"Eggplant"
+					]
+				},
+				{
+					"value": "206, 255, 29",
+					"synonyms": [
+						"Electric Lime"
+					]
+				},
+				{
+					"value": "113, 188, 120",
+					"synonyms": [
+						"Fern"
+					]
+				},
+				{
+					"value": "109, 174, 129",
+					"synonyms": [
+						"Forest Green"
+					]
+				},
+				{
+					"value": "195, 100, 197",
+					"synonyms": [
+						"Fuchsia"
+					]
+				},
+				{
+					"value": "204, 102, 102",
+					"synonyms": [
+						"Fuzzy Wuzzy"
+					]
+				},
+				{
+					"value": "231, 198, 151",
+					"synonyms": [
+						"Gold"
+					]
+				},
+				{
+					"value": "252, 217, 117",
+					"synonyms": [
+						"Goldenrod"
+					]
+				},
+				{
+					"value": "168, 228, 160",
+					"synonyms": [
+						"Granny Smith Apple"
+					]
+				},
+				{
+					"value": "149, 145, 140",
+					"synonyms": [
+						"Gray"
+					]
+				},
+				{
+					"value": "28, 172, 120",
+					"synonyms": [
+						"Green"
+					]
+				},
+				{
+					"value": "17, 100, 180",
+					"synonyms": [
+						"Green Blue"
+					]
+				},
+				{
+					"value": "240, 232, 145",
+					"synonyms": [
+						"Green Yellow"
+					]
+				},
+				{
+					"value": "255, 29, 206",
+					"synonyms": [
+						"Hot Magenta"
+					]
+				},
+				{
+					"value": "178, 236, 93",
+					"synonyms": [
+						"Inchworm"
+					]
+				},
+				{
+					"value": "93, 118, 203",
+					"synonyms": [
+						"Indigo"
+					]
+				},
+				{
+					"value": "202, 55, 103",
+					"synonyms": [
+						"Jazzberry Jam"
+					]
+				},
+				{
+					"value": "59, 176, 143",
+					"synonyms": [
+						"Jungle Green"
+					]
+				},
+				{
+					"value": "254, 254, 34",
+					"synonyms": [
+						"Laser Lemon"
+					]
+				},
+				{
+					"value": "252, 180, 213",
+					"synonyms": [
+						"Lavender"
+					]
+				},
+				{
+					"value": "255, 244, 79",
+					"synonyms": [
+						"Lemon Yellow"
+					]
+				},
+				{
+					"value": "255, 189, 136",
+					"synonyms": [
+						"Macaroni and Cheese"
+					]
+				},
+				{
+					"value": "246, 100, 175",
+					"synonyms": [
+						"Magenta"
+					]
+				},
+				{
+					"value": "170, 240, 209",
+					"synonyms": [
+						"Magic Mint"
+					]
+				},
+				{
+					"value": "205, 74, 76",
+					"synonyms": [
+						"Mahogany"
+					]
+				},
+				{
+					"value": "237, 209, 156",
+					"synonyms": [
+						"Maize"
+					]
+				},
+				{
+					"value": "151, 154, 170",
+					"synonyms": [
+						"Manatee"
+					]
+				},
+				{
+					"value": "255, 130, 67",
+					"synonyms": [
+						"Mango Tango"
+					]
+				},
+				{
+					"value": "200, 56, 90",
+					"synonyms": [
+						"Maroon"
+					]
+				},
+				{
+					"value": "239, 152, 170",
+					"synonyms": [
+						"Mauvelous"
+					]
+				},
+				{
+					"value": "253, 188, 180",
+					"synonyms": [
+						"Melon"
+					]
+				},
+				{
+					"value": "26, 72, 118",
+					"synonyms": [
+						"Midnight Blue"
+					]
+				},
+				{
+					"value": "48, 186, 143",
+					"synonyms": [
+						"Mountain Meadow"
+					]
+				},
+				{
+					"value": "197, 75, 140",
+					"synonyms": [
+						"Mulberry"
+					]
+				},
+				{
+					"value": "25, 116, 210",
+					"synonyms": [
+						"Navy Blue"
+					]
+				},
+				{
+					"value": "255, 163, 67",
+					"synonyms": [
+						"Neon Carrot"
+					]
+				},
+				{
+					"value": "186, 184, 108",
+					"synonyms": [
+						"Olive Green"
+					]
+				},
+				{
+					"value": "255, 117, 56",
+					"synonyms": [
+						"Orange"
+					]
+				},
+				{
+					"value": "255, 43, 43",
+					"synonyms": [
+						"Orange Red"
+					]
+				},
+				{
+					"value": "248, 213, 104",
+					"synonyms": [
+						"Orange Yellow"
+					]
+				},
+				{
+					"value": "230, 168, 215",
+					"synonyms": [
+						"Orchid"
+					]
+				},
+				{
+					"value": "65, 74, 76",
+					"synonyms": [
+						"Outer Space"
+					]
+				},
+				{
+					"value": "255, 110, 74",
+					"synonyms": [
+						"Outrageous Orange"
+					]
+				},
+				{
+					"value": "28, 169, 201",
+					"synonyms": [
+						"Pacific Blue"
+					]
+				},
+				{
+					"value": "255, 207, 171",
+					"synonyms": [
+						"Peach"
+					]
+				},
+				{
+					"value": "197, 208, 230",
+					"synonyms": [
+						"Periwinkle"
+					]
+				},
+				{
+					"value": "253, 221, 230",
+					"synonyms": [
+						"Piggy Pink"
+					]
+				},
+				{
+					"value": "21, 128, 120",
+					"synonyms": [
+						"Pine Green"
+					]
+				},
+				{
+					"value": "252, 116, 253",
+					"synonyms": [
+						"Pink Flamingo"
+					]
+				},
+				{
+					"value": "247, 143, 167",
+					"synonyms": [
+						"Pink Sherbet"
+					]
+				},
+				{
+					"value": "142, 69, 133",
+					"synonyms": [
+						"Plum"
+					]
+				},
+				{
+					"value": "116, 66, 200",
+					"synonyms": [
+						"Purple Heart"
+					]
+				},
+				{
+					"value": "157, 129, 186",
+					"synonyms": [
+						"Purple Mountain's Majesty"
+					]
+				},
+				{
+					"value": "254, 78, 218",
+					"synonyms": [
+						"Purple Pizzazz"
+					]
+				},
+				{
+					"value": "255, 73, 108",
+					"synonyms": [
+						"Radical Red"
+					]
+				},
+				{
+					"value": "214, 138, 89",
+					"synonyms": [
+						"Raw Sienna"
+					]
+				},
+				{
+					"value": "113, 75, 35",
+					"synonyms": [
+						"Raw Umber"
+					]
+				},
+				{
+					"value": "255, 72, 208",
+					"synonyms": [
+						"Razzle Dazzle Rose"
+					]
+				},
+				{
+					"value": "227, 37, 107",
+					"synonyms": [
+						"Razzmatazz"
+					]
+				},
+				{
+					"value": "238,32 ,77 ",
+					"synonyms": [
+						"Red"
+					]
+				},
+				{
+					"value": "255, 83, 73",
+					"synonyms": [
+						"Red Orange"
+					]
+				},
+				{
+					"value": "192, 68, 143",
+					"synonyms": [
+						"Red Violet"
+					]
+				},
+				{
+					"value": "31, 206, 203",
+					"synonyms": [
+						"Robin's Egg Blue"
+					]
+				},
+				{
+					"value": "120, 81, 169",
+					"synonyms": [
+						"Royal Purple"
+					]
+				},
+				{
+					"value": "255, 155, 170",
+					"synonyms": [
+						"Salmon"
+					]
+				},
+				{
+					"value": "252, 40, 71",
+					"synonyms": [
+						"Scarlet"
+					]
+				},
+				{
+					"value": "118, 255, 122",
+					"synonyms": [
+						"Screamin' Green"
+					]
+				},
+				{
+					"value": "159, 226, 191",
+					"synonyms": [
+						"Sea Green"
+					]
+				},
+				{
+					"value": "165, 105, 79",
+					"synonyms": [
+						"Sepia"
+					]
+				},
+				{
+					"value": "138, 121, 93",
+					"synonyms": [
+						"Shadow"
+					]
+				},
+				{
+					"value": "69, 206, 162",
+					"synonyms": [
+						"Shamrock"
+					]
+				},
+				{
+					"value": "251, 126, 253",
+					"synonyms": [
+						"Shocking Pink"
+					]
+				},
+				{
+					"value": "205, 197, 194",
+					"synonyms": [
+						"Silver"
+					]
+				},
+				{
+					"value": "128, 218, 235",
+					"synonyms": [
+						"Sky Blue"
+					]
+				},
+				{
+					"value": "236, 234, 190",
+					"synonyms": [
+						"Spring Green"
+					]
+				},
+				{
+					"value": "255, 207, 72",
+					"synonyms": [
+						"Sunglow"
+					]
+				},
+				{
+					"value": "253, 94, 83",
+					"synonyms": [
+						"Sunset Orange"
+					]
+				},
+				{
+					"value": "250, 167, 108",
+					"synonyms": [
+						"Tan"
+					]
+				},
+				{
+					"value": "24, 167, 181",
+					"synonyms": [
+						"Teal Blue"
+					]
+				},
+				{
+					"value": "235, 199, 223",
+					"synonyms": [
+						"Thistle"
+					]
+				},
+				{
+					"value": "252, 137, 172",
+					"synonyms": [
+						"Tickle Me Pink"
+					]
+				},
+				{
+					"value": "219, 215, 210",
+					"synonyms": [
+						"Timberwolf"
+					]
+				},
+				{
+					"value": "23, 128, 109",
+					"synonyms": [
+						"Tropical Rain Forest"
+					]
+				},
+				{
+					"value": "222, 170, 136",
+					"synonyms": [
+						"Tumbleweed"
+					]
+				},
+				{
+					"value": "119, 221, 231",
+					"synonyms": [
+						"Turquoise Blue"
+					]
+				},
+				{
+					"value": "255, 255, 102",
+					"synonyms": [
+						"Unmellow Yellow"
+					]
+				},
+				{
+					"value": "146, 110, 174",
+					"synonyms": [
+						"Violet (Purple"
+					]
+				},
+				{
+					"value": "50, 74, 178",
+					"synonyms": [
+						"Violet Blue"
+					]
+				},
+				{
+					"value": "247, 83, 148",
+					"synonyms": [
+						"Violet Red"
+					]
+				},
+				{
+					"value": "255, 160, 137",
+					"synonyms": [
+						"Vivid Tangerine"
+					]
+				},
+				{
+					"value": "143, 80, 157",
+					"synonyms": [
+						"Vivid Violet"
+					]
+				},
+				{
+					"value": "255, 255, 255",
+					"synonyms": [
+						"White"
+					]
+				},
+				{
+					"value": "162, 173, 208",
+					"synonyms": [
+						"Wild Blue Yonder"
+					]
+				},
+				{
+					"value": "255, 67, 164",
+					"synonyms": [
+						"Wild Strawberry"
+					]
+				},
+				{
+					"value": "252, 108, 133",
+					"synonyms": [
+						"Wild Watermelon"
+					]
+				},
+				{
+					"value": "205, 164, 222",
+					"synonyms": [
+						"Wisteria"
+					]
+				},
+				{
+					"value": "252, 232, 131",
+					"synonyms": [
+						"Yellow"
+					]
+				},
+				{
+					"value": "197, 227, 132",
+					"synonyms": [
+						"Yellow Green"
+					]
+				},
+				{
+					"value": "255, 174, 66",
+					"synonyms": [
+						"Yellow Orange"
+					]
+				}
+			]
 		}
 	]
 }

--- a/dialogTemplate/en.json
+++ b/dialogTemplate/en.json
@@ -28111,799 +28111,799 @@
 			"useSynonyms": true,
 			"values": [
 				{
-					"value": "(239, 222, 205)",
+					"value": "239, 222, 205",
 					"synonyms": [
 						"Almond"
 					]
 				},
 				{
-					"value": "(205, 149, 117)",
+					"value": "205, 149, 117",
 					"synonyms": [
 						"Antique Brass"
 					]
 				},
 				{
-					"value": "(253, 217, 181)",
+					"value": "253, 217, 181",
 					"synonyms": [
 						"Apricot"
 					]
 				},
 				{
-					"value": "(120, 219, 226)",
+					"value": "120, 219, 226",
 					"synonyms": [
 						"Aquamarine"
 					]
 				},
 				{
-					"value": "(135, 169, 107)",
+					"value": "135, 169, 107",
 					"synonyms": [
 						"Asparagus"
 					]
 				},
 				{
-					"value": "(255, 164, 116)",
+					"value": "255, 164, 116",
 					"synonyms": [
 						"Atomic Tangerine"
 					]
 				},
 				{
-					"value": "(250, 231, 181)",
+					"value": "250, 231, 181",
 					"synonyms": [
 						"Banana Mania"
 					]
 				},
 				{
-					"value": "(159, 129, 112)",
+					"value": "159, 129, 112",
 					"synonyms": [
 						"Beaver"
 					]
 				},
 				{
-					"value": "(253, 124, 110)",
+					"value": "253, 124, 110",
 					"synonyms": [
 						"Bittersweet"
 					]
 				},
 				{
-					"value": "(0,0,0)",
+					"value": "0,0,0",
 					"synonyms": [
 						"Black"
 					]
 				},
 				{
-					"value": "(172, 229, 238)",
+					"value": "172, 229, 238",
 					"synonyms": [
 						"Blizzard Blue"
 					]
 				},
 				{
-					"value": "(31, 117, 254)",
+					"value": "31, 117, 254",
 					"synonyms": [
 						"Blue"
 					]
 				},
 				{
-					"value": "(162, 162, 208)",
+					"value": "162, 162, 208",
 					"synonyms": [
 						"Blue Bell"
 					]
 				},
 				{
-					"value": "(102, 153, 204)",
+					"value": "102, 153, 204",
 					"synonyms": [
 						"Blue Gray"
 					]
 				},
 				{
-					"value": "(13, 152, 186)",
+					"value": "13, 152, 186",
 					"synonyms": [
 						"Blue Green"
 					]
 				},
 				{
-					"value": "(115, 102, 189)",
+					"value": "115, 102, 189",
 					"synonyms": [
 						"Blue Violet"
 					]
 				},
 				{
-					"value": "(222, 93, 131)",
+					"value": "222, 93, 131",
 					"synonyms": [
 						"Blush"
 					]
 				},
 				{
-					"value": "(203, 65, 84)",
+					"value": "203, 65, 84",
 					"synonyms": [
 						"Brick Red"
 					]
 				},
 				{
-					"value": "(180, 103, 77)",
+					"value": "180, 103, 77",
 					"synonyms": [
 						"Brown"
 					]
 				},
 				{
-					"value": "(255, 127, 73)",
+					"value": "255, 127, 73",
 					"synonyms": [
 						"Burnt Orange"
 					]
 				},
 				{
-					"value": "(234, 126, 93)",
+					"value": "234, 126, 93",
 					"synonyms": [
 						"Burnt Sienna"
 					]
 				},
 				{
-					"value": "(176, 183, 198)",
+					"value": "176, 183, 198",
 					"synonyms": [
 						"Cadet Blue"
 					]
 				},
 				{
-					"value": "(255, 255, 153)",
+					"value": "255, 255, 153",
 					"synonyms": [
 						"Canary"
 					]
 				},
 				{
-					"value": "(28, 211, 162)",
+					"value": "28, 211, 162",
 					"synonyms": [
 						"Caribbean Green"
 					]
 				},
 				{
-					"value": "(255, 170, 204)",
+					"value": "255, 170, 204",
 					"synonyms": [
 						"Carnation Pink"
 					]
 				},
 				{
-					"value": "(221, 68, 146)",
+					"value": "221, 68, 146",
 					"synonyms": [
 						"Cerise"
 					]
 				},
 				{
-					"value": "(29, 172, 214)",
+					"value": "29, 172, 214",
 					"synonyms": [
 						"Cerulean"
 					]
 				},
 				{
-					"value": "(188, 93, 88)",
+					"value": "188, 93, 88",
 					"synonyms": [
 						"Chestnut"
 					]
 				},
 				{
-					"value": "(221, 148, 117)",
+					"value": "221, 148, 117",
 					"synonyms": [
 						"Copper"
 					]
 				},
 				{
-					"value": "(154, 206, 235)",
+					"value": "154, 206, 235",
 					"synonyms": [
 						"Cornflower"
 					]
 				},
 				{
-					"value": "(255, 188, 217)",
+					"value": "255, 188, 217",
 					"synonyms": [
 						"Cotton Candy"
 					]
 				},
 				{
-					"value": "(253, 219, 109)",
+					"value": "253, 219, 109",
 					"synonyms": [
 						"Dandelion"
 					]
 				},
 				{
-					"value": "(43, 108, 196)",
+					"value": "43, 108, 196",
 					"synonyms": [
 						"Denim"
 					]
 				},
 				{
-					"value": "(239, 205, 184)",
+					"value": "239, 205, 184",
 					"synonyms": [
 						"Desert Sand"
 					]
 				},
 				{
-					"value": "(110, 81, 96)",
+					"value": "110, 81, 96",
 					"synonyms": [
 						"Eggplant"
 					]
 				},
 				{
-					"value": "(206, 255, 29)",
+					"value": "206, 255, 29",
 					"synonyms": [
 						"Electric Lime"
 					]
 				},
 				{
-					"value": "(113, 188, 120)",
+					"value": "113, 188, 120",
 					"synonyms": [
 						"Fern"
 					]
 				},
 				{
-					"value": "(109, 174, 129)",
+					"value": "109, 174, 129",
 					"synonyms": [
 						"Forest Green"
 					]
 				},
 				{
-					"value": "(195, 100, 197)",
+					"value": "195, 100, 197",
 					"synonyms": [
 						"Fuchsia"
 					]
 				},
 				{
-					"value": "(204, 102, 102)",
+					"value": "204, 102, 102",
 					"synonyms": [
 						"Fuzzy Wuzzy"
 					]
 				},
 				{
-					"value": "(231, 198, 151)",
+					"value": "231, 198, 151",
 					"synonyms": [
 						"Gold"
 					]
 				},
 				{
-					"value": "(252, 217, 117)",
+					"value": "252, 217, 117",
 					"synonyms": [
 						"Goldenrod"
 					]
 				},
 				{
-					"value": "(168, 228, 160)",
+					"value": "168, 228, 160",
 					"synonyms": [
 						"Granny Smith Apple"
 					]
 				},
 				{
-					"value": "(149, 145, 140)",
+					"value": "149, 145, 140",
 					"synonyms": [
 						"Gray"
 					]
 				},
 				{
-					"value": "(28, 172, 120)",
+					"value": "28, 172, 120",
 					"synonyms": [
 						"Green"
 					]
 				},
 				{
-					"value": "(17, 100, 180)",
+					"value": "17, 100, 180",
 					"synonyms": [
 						"Green Blue"
 					]
 				},
 				{
-					"value": "(240, 232, 145)",
+					"value": "240, 232, 145",
 					"synonyms": [
 						"Green Yellow"
 					]
 				},
 				{
-					"value": "(255, 29, 206)",
+					"value": "255, 29, 206",
 					"synonyms": [
 						"Hot Magenta"
 					]
 				},
 				{
-					"value": "(178, 236, 93)",
+					"value": "178, 236, 93",
 					"synonyms": [
 						"Inchworm"
 					]
 				},
 				{
-					"value": "(93, 118, 203)",
+					"value": "93, 118, 203",
 					"synonyms": [
 						"Indigo"
 					]
 				},
 				{
-					"value": "(202, 55, 103)",
+					"value": "202, 55, 103",
 					"synonyms": [
 						"Jazzberry Jam"
 					]
 				},
 				{
-					"value": "(59, 176, 143)",
+					"value": "59, 176, 143",
 					"synonyms": [
 						"Jungle Green"
 					]
 				},
 				{
-					"value": "(254, 254, 34)",
+					"value": "254, 254, 34",
 					"synonyms": [
 						"Laser Lemon"
 					]
 				},
 				{
-					"value": "(252, 180, 213)",
+					"value": "252, 180, 213",
 					"synonyms": [
 						"Lavender"
 					]
 				},
 				{
-					"value": "(255, 244, 79)",
+					"value": "255, 244, 79",
 					"synonyms": [
 						"Lemon Yellow"
 					]
 				},
 				{
-					"value": "(255, 189, 136)",
+					"value": "255, 189, 136",
 					"synonyms": [
 						"Macaroni and Cheese"
 					]
 				},
 				{
-					"value": "(246, 100, 175)",
+					"value": "246, 100, 175",
 					"synonyms": [
 						"Magenta"
 					]
 				},
 				{
-					"value": "(170, 240, 209)",
+					"value": "170, 240, 209",
 					"synonyms": [
 						"Magic Mint"
 					]
 				},
 				{
-					"value": "(205, 74, 76)",
+					"value": "205, 74, 76",
 					"synonyms": [
 						"Mahogany"
 					]
 				},
 				{
-					"value": "(237, 209, 156)",
+					"value": "237, 209, 156",
 					"synonyms": [
 						"Maize"
 					]
 				},
 				{
-					"value": "(151, 154, 170)",
+					"value": "151, 154, 170",
 					"synonyms": [
 						"Manatee"
 					]
 				},
 				{
-					"value": "(255, 130, 67)",
+					"value": "255, 130, 67",
 					"synonyms": [
 						"Mango Tango"
 					]
 				},
 				{
-					"value": "(200, 56, 90)",
+					"value": "200, 56, 90",
 					"synonyms": [
 						"Maroon"
 					]
 				},
 				{
-					"value": "(239, 152, 170)",
+					"value": "239, 152, 170",
 					"synonyms": [
 						"Mauvelous"
 					]
 				},
 				{
-					"value": "(253, 188, 180)",
+					"value": "253, 188, 180",
 					"synonyms": [
 						"Melon"
 					]
 				},
 				{
-					"value": "(26, 72, 118)",
+					"value": "26, 72, 118",
 					"synonyms": [
 						"Midnight Blue"
 					]
 				},
 				{
-					"value": "(48, 186, 143)",
+					"value": "48, 186, 143",
 					"synonyms": [
 						"Mountain Meadow"
 					]
 				},
 				{
-					"value": "(197, 75, 140)",
+					"value": "197, 75, 140",
 					"synonyms": [
 						"Mulberry"
 					]
 				},
 				{
-					"value": "(25, 116, 210)",
+					"value": "25, 116, 210",
 					"synonyms": [
 						"Navy Blue"
 					]
 				},
 				{
-					"value": "(255, 163, 67)",
+					"value": "255, 163, 67",
 					"synonyms": [
 						"Neon Carrot"
 					]
 				},
 				{
-					"value": "(186, 184, 108)",
+					"value": "186, 184, 108",
 					"synonyms": [
 						"Olive Green"
 					]
 				},
 				{
-					"value": "(255, 117, 56)",
+					"value": "255, 117, 56",
 					"synonyms": [
 						"Orange"
 					]
 				},
 				{
-					"value": "(255, 43, 43)",
+					"value": "255, 43, 43",
 					"synonyms": [
 						"Orange Red"
 					]
 				},
 				{
-					"value": "(248, 213, 104)",
+					"value": "248, 213, 104",
 					"synonyms": [
 						"Orange Yellow"
 					]
 				},
 				{
-					"value": "(230, 168, 215)",
+					"value": "230, 168, 215",
 					"synonyms": [
 						"Orchid"
 					]
 				},
 				{
-					"value": "(65, 74, 76)",
+					"value": "65, 74, 76",
 					"synonyms": [
 						"Outer Space"
 					]
 				},
 				{
-					"value": "(255, 110, 74)",
+					"value": "255, 110, 74",
 					"synonyms": [
 						"Outrageous Orange"
 					]
 				},
 				{
-					"value": "(28, 169, 201)",
+					"value": "28, 169, 201",
 					"synonyms": [
 						"Pacific Blue"
 					]
 				},
 				{
-					"value": "(255, 207, 171)",
+					"value": "255, 207, 171",
 					"synonyms": [
 						"Peach"
 					]
 				},
 				{
-					"value": "(197, 208, 230)",
+					"value": "197, 208, 230",
 					"synonyms": [
 						"Periwinkle"
 					]
 				},
 				{
-					"value": "(253, 221, 230)",
+					"value": "253, 221, 230",
 					"synonyms": [
 						"Piggy Pink"
 					]
 				},
 				{
-					"value": "(21, 128, 120)",
+					"value": "21, 128, 120",
 					"synonyms": [
 						"Pine Green"
 					]
 				},
 				{
-					"value": "(252, 116, 253)",
+					"value": "252, 116, 253",
 					"synonyms": [
 						"Pink Flamingo"
 					]
 				},
 				{
-					"value": "(247, 143, 167)",
+					"value": "247, 143, 167",
 					"synonyms": [
 						"Pink Sherbet"
 					]
 				},
 				{
-					"value": "(142, 69, 133)",
+					"value": "142, 69, 133",
 					"synonyms": [
 						"Plum"
 					]
 				},
 				{
-					"value": "(116, 66, 200)",
+					"value": "116, 66, 200",
 					"synonyms": [
 						"Purple Heart"
 					]
 				},
 				{
-					"value": "(157, 129, 186)",
+					"value": "157, 129, 186",
 					"synonyms": [
 						"Purple Mountain's Majesty"
 					]
 				},
 				{
-					"value": "(254, 78, 218)",
+					"value": "254, 78, 218",
 					"synonyms": [
 						"Purple Pizzazz"
 					]
 				},
 				{
-					"value": "(255, 73, 108)",
+					"value": "255, 73, 108",
 					"synonyms": [
 						"Radical Red"
 					]
 				},
 				{
-					"value": "(214, 138, 89)",
+					"value": "214, 138, 89",
 					"synonyms": [
 						"Raw Sienna"
 					]
 				},
 				{
-					"value": "(113, 75, 35)",
+					"value": "113, 75, 35",
 					"synonyms": [
 						"Raw Umber"
 					]
 				},
 				{
-					"value": "(255, 72, 208)",
+					"value": "255, 72, 208",
 					"synonyms": [
 						"Razzle Dazzle Rose"
 					]
 				},
 				{
-					"value": "(227, 37, 107)",
+					"value": "227, 37, 107",
 					"synonyms": [
 						"Razzmatazz"
 					]
 				},
 				{
-					"value": "(238,32 ,77 )",
+					"value": "238,32 ,77 ",
 					"synonyms": [
 						"Red"
 					]
 				},
 				{
-					"value": "(255, 83, 73)",
+					"value": "255, 83, 73",
 					"synonyms": [
 						"Red Orange"
 					]
 				},
 				{
-					"value": "(192, 68, 143)",
+					"value": "192, 68, 143",
 					"synonyms": [
 						"Red Violet"
 					]
 				},
 				{
-					"value": "(31, 206, 203)",
+					"value": "31, 206, 203",
 					"synonyms": [
 						"Robin's Egg Blue"
 					]
 				},
 				{
-					"value": "(120, 81, 169)",
+					"value": "120, 81, 169",
 					"synonyms": [
 						"Royal Purple"
 					]
 				},
 				{
-					"value": "(255, 155, 170)",
+					"value": "255, 155, 170",
 					"synonyms": [
 						"Salmon"
 					]
 				},
 				{
-					"value": "(252, 40, 71)",
+					"value": "252, 40, 71",
 					"synonyms": [
 						"Scarlet"
 					]
 				},
 				{
-					"value": "(118, 255, 122)",
+					"value": "118, 255, 122",
 					"synonyms": [
 						"Screamin' Green"
 					]
 				},
 				{
-					"value": "(159, 226, 191)",
+					"value": "159, 226, 191",
 					"synonyms": [
 						"Sea Green"
 					]
 				},
 				{
-					"value": "(165, 105, 79)",
+					"value": "165, 105, 79",
 					"synonyms": [
 						"Sepia"
 					]
 				},
 				{
-					"value": "(138, 121, 93)",
+					"value": "138, 121, 93",
 					"synonyms": [
 						"Shadow"
 					]
 				},
 				{
-					"value": "(69, 206, 162)",
+					"value": "69, 206, 162",
 					"synonyms": [
 						"Shamrock"
 					]
 				},
 				{
-					"value": "(251, 126, 253)",
+					"value": "251, 126, 253",
 					"synonyms": [
 						"Shocking Pink"
 					]
 				},
 				{
-					"value": "(205, 197, 194)",
+					"value": "205, 197, 194",
 					"synonyms": [
 						"Silver"
 					]
 				},
 				{
-					"value": "(128, 218, 235)",
+					"value": "128, 218, 235",
 					"synonyms": [
 						"Sky Blue"
 					]
 				},
 				{
-					"value": "(236, 234, 190)",
+					"value": "236, 234, 190",
 					"synonyms": [
 						"Spring Green"
 					]
 				},
 				{
-					"value": "(255, 207, 72)",
+					"value": "255, 207, 72",
 					"synonyms": [
 						"Sunglow"
 					]
 				},
 				{
-					"value": "(253, 94, 83)",
+					"value": "253, 94, 83",
 					"synonyms": [
 						"Sunset Orange"
 					]
 				},
 				{
-					"value": "(250, 167, 108)",
+					"value": "250, 167, 108",
 					"synonyms": [
 						"Tan"
 					]
 				},
 				{
-					"value": "(24, 167, 181)",
+					"value": "24, 167, 181",
 					"synonyms": [
 						"Teal Blue"
 					]
 				},
 				{
-					"value": "(235, 199, 223)",
+					"value": "235, 199, 223",
 					"synonyms": [
 						"Thistle"
 					]
 				},
 				{
-					"value": "(252, 137, 172)",
+					"value": "252, 137, 172",
 					"synonyms": [
 						"Tickle Me Pink"
 					]
 				},
 				{
-					"value": "(219, 215, 210)",
+					"value": "219, 215, 210",
 					"synonyms": [
 						"Timberwolf"
 					]
 				},
 				{
-					"value": "(23, 128, 109)",
+					"value": "23, 128, 109",
 					"synonyms": [
 						"Tropical Rain Forest"
 					]
 				},
 				{
-					"value": "(222, 170, 136)",
+					"value": "222, 170, 136",
 					"synonyms": [
 						"Tumbleweed"
 					]
 				},
 				{
-					"value": "(119, 221, 231)",
+					"value": "119, 221, 231",
 					"synonyms": [
 						"Turquoise Blue"
 					]
 				},
 				{
-					"value": "(255, 255, 102)",
+					"value": "255, 255, 102",
 					"synonyms": [
 						"Unmellow Yellow"
 					]
 				},
 				{
-					"value": "(146, 110, 174)",
+					"value": "146, 110, 174",
 					"synonyms": [
-						"Violet (Purple)"
+						"Violet (Purple"
 					]
 				},
 				{
-					"value": "(50, 74, 178)",
+					"value": "50, 74, 178",
 					"synonyms": [
 						"Violet Blue"
 					]
 				},
 				{
-					"value": "(247, 83, 148)",
+					"value": "247, 83, 148",
 					"synonyms": [
 						"Violet Red"
 					]
 				},
 				{
-					"value": "(255, 160, 137)",
+					"value": "255, 160, 137",
 					"synonyms": [
 						"Vivid Tangerine"
 					]
 				},
 				{
-					"value": "(143, 80, 157)",
+					"value": "143, 80, 157",
 					"synonyms": [
 						"Vivid Violet"
 					]
 				},
 				{
-					"value": "(255, 255, 255)",
+					"value": "255, 255, 255",
 					"synonyms": [
 						"White"
 					]
 				},
 				{
-					"value": "(162, 173, 208)",
+					"value": "162, 173, 208",
 					"synonyms": [
 						"Wild Blue Yonder"
 					]
 				},
 				{
-					"value": "(255, 67, 164)",
+					"value": "255, 67, 164",
 					"synonyms": [
 						"Wild Strawberry"
 					]
 				},
 				{
-					"value": "(252, 108, 133)",
+					"value": "252, 108, 133",
 					"synonyms": [
 						"Wild Watermelon"
 					]
 				},
 				{
-					"value": "(205, 164, 222)",
+					"value": "205, 164, 222",
 					"synonyms": [
 						"Wisteria"
 					]
 				},
 				{
-					"value": "(252, 232, 131)",
+					"value": "252, 232, 131",
 					"synonyms": [
 						"Yellow"
 					]
 				},
 				{
-					"value": "(197, 227, 132)",
+					"value": "197, 227, 132",
 					"synonyms": [
 						"Yellow Green"
 					]
 				},
 				{
-					"value": "(255, 174, 66)",
+					"value": "255, 174, 66",
 					"synonyms": [
 						"Yellow Orange"
 					]

--- a/dialogTemplate/en.json
+++ b/dialogTemplate/en.json
@@ -28105,7 +28105,7 @@
 			]
 		},
 		{
-			"name": "Alice/Colours",
+			"name": "Alice/Colors",
 			"matchingStrictness": null,
 			"automaticallyExtensible": true,
 			"useSynonyms": true,

--- a/dialogTemplate/en.json
+++ b/dialogTemplate/en.json
@@ -28103,6 +28103,812 @@
 					"value": "zone"
 				}
 			]
+		},
+		{
+			"name": "Alice/Colours",
+			"matchingStrictness": null,
+			"automaticallyExtensible": true,
+			"useSynonyms": true,
+			"values": [
+				{
+					"value": "(239, 222, 205)",
+					"synonyms": [
+						"Almond"
+					]
+				},
+				{
+					"value": "(205, 149, 117)",
+					"synonyms": [
+						"Antique Brass"
+					]
+				},
+				{
+					"value": "(253, 217, 181)",
+					"synonyms": [
+						"Apricot"
+					]
+				},
+				{
+					"value": "(120, 219, 226)",
+					"synonyms": [
+						"Aquamarine"
+					]
+				},
+				{
+					"value": "(135, 169, 107)",
+					"synonyms": [
+						"Asparagus"
+					]
+				},
+				{
+					"value": "(255, 164, 116)",
+					"synonyms": [
+						"Atomic Tangerine"
+					]
+				},
+				{
+					"value": "(250, 231, 181)",
+					"synonyms": [
+						"Banana Mania"
+					]
+				},
+				{
+					"value": "(159, 129, 112)",
+					"synonyms": [
+						"Beaver"
+					]
+				},
+				{
+					"value": "(253, 124, 110)",
+					"synonyms": [
+						"Bittersweet"
+					]
+				},
+				{
+					"value": "(0,0,0)",
+					"synonyms": [
+						"Black"
+					]
+				},
+				{
+					"value": "(172, 229, 238)",
+					"synonyms": [
+						"Blizzard Blue"
+					]
+				},
+				{
+					"value": "(31, 117, 254)",
+					"synonyms": [
+						"Blue"
+					]
+				},
+				{
+					"value": "(162, 162, 208)",
+					"synonyms": [
+						"Blue Bell"
+					]
+				},
+				{
+					"value": "(102, 153, 204)",
+					"synonyms": [
+						"Blue Gray"
+					]
+				},
+				{
+					"value": "(13, 152, 186)",
+					"synonyms": [
+						"Blue Green"
+					]
+				},
+				{
+					"value": "(115, 102, 189)",
+					"synonyms": [
+						"Blue Violet"
+					]
+				},
+				{
+					"value": "(222, 93, 131)",
+					"synonyms": [
+						"Blush"
+					]
+				},
+				{
+					"value": "(203, 65, 84)",
+					"synonyms": [
+						"Brick Red"
+					]
+				},
+				{
+					"value": "(180, 103, 77)",
+					"synonyms": [
+						"Brown"
+					]
+				},
+				{
+					"value": "(255, 127, 73)",
+					"synonyms": [
+						"Burnt Orange"
+					]
+				},
+				{
+					"value": "(234, 126, 93)",
+					"synonyms": [
+						"Burnt Sienna"
+					]
+				},
+				{
+					"value": "(176, 183, 198)",
+					"synonyms": [
+						"Cadet Blue"
+					]
+				},
+				{
+					"value": "(255, 255, 153)",
+					"synonyms": [
+						"Canary"
+					]
+				},
+				{
+					"value": "(28, 211, 162)",
+					"synonyms": [
+						"Caribbean Green"
+					]
+				},
+				{
+					"value": "(255, 170, 204)",
+					"synonyms": [
+						"Carnation Pink"
+					]
+				},
+				{
+					"value": "(221, 68, 146)",
+					"synonyms": [
+						"Cerise"
+					]
+				},
+				{
+					"value": "(29, 172, 214)",
+					"synonyms": [
+						"Cerulean"
+					]
+				},
+				{
+					"value": "(188, 93, 88)",
+					"synonyms": [
+						"Chestnut"
+					]
+				},
+				{
+					"value": "(221, 148, 117)",
+					"synonyms": [
+						"Copper"
+					]
+				},
+				{
+					"value": "(154, 206, 235)",
+					"synonyms": [
+						"Cornflower"
+					]
+				},
+				{
+					"value": "(255, 188, 217)",
+					"synonyms": [
+						"Cotton Candy"
+					]
+				},
+				{
+					"value": "(253, 219, 109)",
+					"synonyms": [
+						"Dandelion"
+					]
+				},
+				{
+					"value": "(43, 108, 196)",
+					"synonyms": [
+						"Denim"
+					]
+				},
+				{
+					"value": "(239, 205, 184)",
+					"synonyms": [
+						"Desert Sand"
+					]
+				},
+				{
+					"value": "(110, 81, 96)",
+					"synonyms": [
+						"Eggplant"
+					]
+				},
+				{
+					"value": "(206, 255, 29)",
+					"synonyms": [
+						"Electric Lime"
+					]
+				},
+				{
+					"value": "(113, 188, 120)",
+					"synonyms": [
+						"Fern"
+					]
+				},
+				{
+					"value": "(109, 174, 129)",
+					"synonyms": [
+						"Forest Green"
+					]
+				},
+				{
+					"value": "(195, 100, 197)",
+					"synonyms": [
+						"Fuchsia"
+					]
+				},
+				{
+					"value": "(204, 102, 102)",
+					"synonyms": [
+						"Fuzzy Wuzzy"
+					]
+				},
+				{
+					"value": "(231, 198, 151)",
+					"synonyms": [
+						"Gold"
+					]
+				},
+				{
+					"value": "(252, 217, 117)",
+					"synonyms": [
+						"Goldenrod"
+					]
+				},
+				{
+					"value": "(168, 228, 160)",
+					"synonyms": [
+						"Granny Smith Apple"
+					]
+				},
+				{
+					"value": "(149, 145, 140)",
+					"synonyms": [
+						"Gray"
+					]
+				},
+				{
+					"value": "(28, 172, 120)",
+					"synonyms": [
+						"Green"
+					]
+				},
+				{
+					"value": "(17, 100, 180)",
+					"synonyms": [
+						"Green Blue"
+					]
+				},
+				{
+					"value": "(240, 232, 145)",
+					"synonyms": [
+						"Green Yellow"
+					]
+				},
+				{
+					"value": "(255, 29, 206)",
+					"synonyms": [
+						"Hot Magenta"
+					]
+				},
+				{
+					"value": "(178, 236, 93)",
+					"synonyms": [
+						"Inchworm"
+					]
+				},
+				{
+					"value": "(93, 118, 203)",
+					"synonyms": [
+						"Indigo"
+					]
+				},
+				{
+					"value": "(202, 55, 103)",
+					"synonyms": [
+						"Jazzberry Jam"
+					]
+				},
+				{
+					"value": "(59, 176, 143)",
+					"synonyms": [
+						"Jungle Green"
+					]
+				},
+				{
+					"value": "(254, 254, 34)",
+					"synonyms": [
+						"Laser Lemon"
+					]
+				},
+				{
+					"value": "(252, 180, 213)",
+					"synonyms": [
+						"Lavender"
+					]
+				},
+				{
+					"value": "(255, 244, 79)",
+					"synonyms": [
+						"Lemon Yellow"
+					]
+				},
+				{
+					"value": "(255, 189, 136)",
+					"synonyms": [
+						"Macaroni and Cheese"
+					]
+				},
+				{
+					"value": "(246, 100, 175)",
+					"synonyms": [
+						"Magenta"
+					]
+				},
+				{
+					"value": "(170, 240, 209)",
+					"synonyms": [
+						"Magic Mint"
+					]
+				},
+				{
+					"value": "(205, 74, 76)",
+					"synonyms": [
+						"Mahogany"
+					]
+				},
+				{
+					"value": "(237, 209, 156)",
+					"synonyms": [
+						"Maize"
+					]
+				},
+				{
+					"value": "(151, 154, 170)",
+					"synonyms": [
+						"Manatee"
+					]
+				},
+				{
+					"value": "(255, 130, 67)",
+					"synonyms": [
+						"Mango Tango"
+					]
+				},
+				{
+					"value": "(200, 56, 90)",
+					"synonyms": [
+						"Maroon"
+					]
+				},
+				{
+					"value": "(239, 152, 170)",
+					"synonyms": [
+						"Mauvelous"
+					]
+				},
+				{
+					"value": "(253, 188, 180)",
+					"synonyms": [
+						"Melon"
+					]
+				},
+				{
+					"value": "(26, 72, 118)",
+					"synonyms": [
+						"Midnight Blue"
+					]
+				},
+				{
+					"value": "(48, 186, 143)",
+					"synonyms": [
+						"Mountain Meadow"
+					]
+				},
+				{
+					"value": "(197, 75, 140)",
+					"synonyms": [
+						"Mulberry"
+					]
+				},
+				{
+					"value": "(25, 116, 210)",
+					"synonyms": [
+						"Navy Blue"
+					]
+				},
+				{
+					"value": "(255, 163, 67)",
+					"synonyms": [
+						"Neon Carrot"
+					]
+				},
+				{
+					"value": "(186, 184, 108)",
+					"synonyms": [
+						"Olive Green"
+					]
+				},
+				{
+					"value": "(255, 117, 56)",
+					"synonyms": [
+						"Orange"
+					]
+				},
+				{
+					"value": "(255, 43, 43)",
+					"synonyms": [
+						"Orange Red"
+					]
+				},
+				{
+					"value": "(248, 213, 104)",
+					"synonyms": [
+						"Orange Yellow"
+					]
+				},
+				{
+					"value": "(230, 168, 215)",
+					"synonyms": [
+						"Orchid"
+					]
+				},
+				{
+					"value": "(65, 74, 76)",
+					"synonyms": [
+						"Outer Space"
+					]
+				},
+				{
+					"value": "(255, 110, 74)",
+					"synonyms": [
+						"Outrageous Orange"
+					]
+				},
+				{
+					"value": "(28, 169, 201)",
+					"synonyms": [
+						"Pacific Blue"
+					]
+				},
+				{
+					"value": "(255, 207, 171)",
+					"synonyms": [
+						"Peach"
+					]
+				},
+				{
+					"value": "(197, 208, 230)",
+					"synonyms": [
+						"Periwinkle"
+					]
+				},
+				{
+					"value": "(253, 221, 230)",
+					"synonyms": [
+						"Piggy Pink"
+					]
+				},
+				{
+					"value": "(21, 128, 120)",
+					"synonyms": [
+						"Pine Green"
+					]
+				},
+				{
+					"value": "(252, 116, 253)",
+					"synonyms": [
+						"Pink Flamingo"
+					]
+				},
+				{
+					"value": "(247, 143, 167)",
+					"synonyms": [
+						"Pink Sherbet"
+					]
+				},
+				{
+					"value": "(142, 69, 133)",
+					"synonyms": [
+						"Plum"
+					]
+				},
+				{
+					"value": "(116, 66, 200)",
+					"synonyms": [
+						"Purple Heart"
+					]
+				},
+				{
+					"value": "(157, 129, 186)",
+					"synonyms": [
+						"Purple Mountain's Majesty"
+					]
+				},
+				{
+					"value": "(254, 78, 218)",
+					"synonyms": [
+						"Purple Pizzazz"
+					]
+				},
+				{
+					"value": "(255, 73, 108)",
+					"synonyms": [
+						"Radical Red"
+					]
+				},
+				{
+					"value": "(214, 138, 89)",
+					"synonyms": [
+						"Raw Sienna"
+					]
+				},
+				{
+					"value": "(113, 75, 35)",
+					"synonyms": [
+						"Raw Umber"
+					]
+				},
+				{
+					"value": "(255, 72, 208)",
+					"synonyms": [
+						"Razzle Dazzle Rose"
+					]
+				},
+				{
+					"value": "(227, 37, 107)",
+					"synonyms": [
+						"Razzmatazz"
+					]
+				},
+				{
+					"value": "(238,32 ,77 )",
+					"synonyms": [
+						"Red"
+					]
+				},
+				{
+					"value": "(255, 83, 73)",
+					"synonyms": [
+						"Red Orange"
+					]
+				},
+				{
+					"value": "(192, 68, 143)",
+					"synonyms": [
+						"Red Violet"
+					]
+				},
+				{
+					"value": "(31, 206, 203)",
+					"synonyms": [
+						"Robin's Egg Blue"
+					]
+				},
+				{
+					"value": "(120, 81, 169)",
+					"synonyms": [
+						"Royal Purple"
+					]
+				},
+				{
+					"value": "(255, 155, 170)",
+					"synonyms": [
+						"Salmon"
+					]
+				},
+				{
+					"value": "(252, 40, 71)",
+					"synonyms": [
+						"Scarlet"
+					]
+				},
+				{
+					"value": "(118, 255, 122)",
+					"synonyms": [
+						"Screamin' Green"
+					]
+				},
+				{
+					"value": "(159, 226, 191)",
+					"synonyms": [
+						"Sea Green"
+					]
+				},
+				{
+					"value": "(165, 105, 79)",
+					"synonyms": [
+						"Sepia"
+					]
+				},
+				{
+					"value": "(138, 121, 93)",
+					"synonyms": [
+						"Shadow"
+					]
+				},
+				{
+					"value": "(69, 206, 162)",
+					"synonyms": [
+						"Shamrock"
+					]
+				},
+				{
+					"value": "(251, 126, 253)",
+					"synonyms": [
+						"Shocking Pink"
+					]
+				},
+				{
+					"value": "(205, 197, 194)",
+					"synonyms": [
+						"Silver"
+					]
+				},
+				{
+					"value": "(128, 218, 235)",
+					"synonyms": [
+						"Sky Blue"
+					]
+				},
+				{
+					"value": "(236, 234, 190)",
+					"synonyms": [
+						"Spring Green"
+					]
+				},
+				{
+					"value": "(255, 207, 72)",
+					"synonyms": [
+						"Sunglow"
+					]
+				},
+				{
+					"value": "(253, 94, 83)",
+					"synonyms": [
+						"Sunset Orange"
+					]
+				},
+				{
+					"value": "(250, 167, 108)",
+					"synonyms": [
+						"Tan"
+					]
+				},
+				{
+					"value": "(24, 167, 181)",
+					"synonyms": [
+						"Teal Blue"
+					]
+				},
+				{
+					"value": "(235, 199, 223)",
+					"synonyms": [
+						"Thistle"
+					]
+				},
+				{
+					"value": "(252, 137, 172)",
+					"synonyms": [
+						"Tickle Me Pink"
+					]
+				},
+				{
+					"value": "(219, 215, 210)",
+					"synonyms": [
+						"Timberwolf"
+					]
+				},
+				{
+					"value": "(23, 128, 109)",
+					"synonyms": [
+						"Tropical Rain Forest"
+					]
+				},
+				{
+					"value": "(222, 170, 136)",
+					"synonyms": [
+						"Tumbleweed"
+					]
+				},
+				{
+					"value": "(119, 221, 231)",
+					"synonyms": [
+						"Turquoise Blue"
+					]
+				},
+				{
+					"value": "(255, 255, 102)",
+					"synonyms": [
+						"Unmellow Yellow"
+					]
+				},
+				{
+					"value": "(146, 110, 174)",
+					"synonyms": [
+						"Violet (Purple)"
+					]
+				},
+				{
+					"value": "(50, 74, 178)",
+					"synonyms": [
+						"Violet Blue"
+					]
+				},
+				{
+					"value": "(247, 83, 148)",
+					"synonyms": [
+						"Violet Red"
+					]
+				},
+				{
+					"value": "(255, 160, 137)",
+					"synonyms": [
+						"Vivid Tangerine"
+					]
+				},
+				{
+					"value": "(143, 80, 157)",
+					"synonyms": [
+						"Vivid Violet"
+					]
+				},
+				{
+					"value": "(255, 255, 255)",
+					"synonyms": [
+						"White"
+					]
+				},
+				{
+					"value": "(162, 173, 208)",
+					"synonyms": [
+						"Wild Blue Yonder"
+					]
+				},
+				{
+					"value": "(255, 67, 164)",
+					"synonyms": [
+						"Wild Strawberry"
+					]
+				},
+				{
+					"value": "(252, 108, 133)",
+					"synonyms": [
+						"Wild Watermelon"
+					]
+				},
+				{
+					"value": "(205, 164, 222)",
+					"synonyms": [
+						"Wisteria"
+					]
+				},
+				{
+					"value": "(252, 232, 131)",
+					"synonyms": [
+						"Yellow"
+					]
+				},
+				{
+					"value": "(197, 227, 132)",
+					"synonyms": [
+						"Yellow Green"
+					]
+				},
+				{
+					"value": "(255, 174, 66)",
+					"synonyms": [
+						"Yellow Orange"
+					]
+				}
+			]
 		}
 	],
 	"intents": [

--- a/dialogTemplate/fr.json
+++ b/dialogTemplate/fr.json
@@ -20450,6 +20450,812 @@
 					"value": "vrai"
 				}
 			]
+		},
+		{
+			"name": "Alice/Colors",
+			"matchingStrictness": null,
+			"automaticallyExtensible": true,
+			"useSynonyms": true,
+			"values": [
+				{
+					"value": "239, 222, 205",
+					"synonyms": [
+						"Almond"
+					]
+				},
+				{
+					"value": "205, 149, 117",
+					"synonyms": [
+						"Antique Brass"
+					]
+				},
+				{
+					"value": "253, 217, 181",
+					"synonyms": [
+						"Apricot"
+					]
+				},
+				{
+					"value": "120, 219, 226",
+					"synonyms": [
+						"Aquamarine"
+					]
+				},
+				{
+					"value": "135, 169, 107",
+					"synonyms": [
+						"Asparagus"
+					]
+				},
+				{
+					"value": "255, 164, 116",
+					"synonyms": [
+						"Atomic Tangerine"
+					]
+				},
+				{
+					"value": "250, 231, 181",
+					"synonyms": [
+						"Banana Mania"
+					]
+				},
+				{
+					"value": "159, 129, 112",
+					"synonyms": [
+						"Beaver"
+					]
+				},
+				{
+					"value": "253, 124, 110",
+					"synonyms": [
+						"Bittersweet"
+					]
+				},
+				{
+					"value": "0,0,0",
+					"synonyms": [
+						"Black"
+					]
+				},
+				{
+					"value": "172, 229, 238",
+					"synonyms": [
+						"Blizzard Blue"
+					]
+				},
+				{
+					"value": "31, 117, 254",
+					"synonyms": [
+						"Blue"
+					]
+				},
+				{
+					"value": "162, 162, 208",
+					"synonyms": [
+						"Blue Bell"
+					]
+				},
+				{
+					"value": "102, 153, 204",
+					"synonyms": [
+						"Blue Gray"
+					]
+				},
+				{
+					"value": "13, 152, 186",
+					"synonyms": [
+						"Blue Green"
+					]
+				},
+				{
+					"value": "115, 102, 189",
+					"synonyms": [
+						"Blue Violet"
+					]
+				},
+				{
+					"value": "222, 93, 131",
+					"synonyms": [
+						"Blush"
+					]
+				},
+				{
+					"value": "203, 65, 84",
+					"synonyms": [
+						"Brick Red"
+					]
+				},
+				{
+					"value": "180, 103, 77",
+					"synonyms": [
+						"Brown"
+					]
+				},
+				{
+					"value": "255, 127, 73",
+					"synonyms": [
+						"Burnt Orange"
+					]
+				},
+				{
+					"value": "234, 126, 93",
+					"synonyms": [
+						"Burnt Sienna"
+					]
+				},
+				{
+					"value": "176, 183, 198",
+					"synonyms": [
+						"Cadet Blue"
+					]
+				},
+				{
+					"value": "255, 255, 153",
+					"synonyms": [
+						"Canary"
+					]
+				},
+				{
+					"value": "28, 211, 162",
+					"synonyms": [
+						"Caribbean Green"
+					]
+				},
+				{
+					"value": "255, 170, 204",
+					"synonyms": [
+						"Carnation Pink"
+					]
+				},
+				{
+					"value": "221, 68, 146",
+					"synonyms": [
+						"Cerise"
+					]
+				},
+				{
+					"value": "29, 172, 214",
+					"synonyms": [
+						"Cerulean"
+					]
+				},
+				{
+					"value": "188, 93, 88",
+					"synonyms": [
+						"Chestnut"
+					]
+				},
+				{
+					"value": "221, 148, 117",
+					"synonyms": [
+						"Copper"
+					]
+				},
+				{
+					"value": "154, 206, 235",
+					"synonyms": [
+						"Cornflower"
+					]
+				},
+				{
+					"value": "255, 188, 217",
+					"synonyms": [
+						"Cotton Candy"
+					]
+				},
+				{
+					"value": "253, 219, 109",
+					"synonyms": [
+						"Dandelion"
+					]
+				},
+				{
+					"value": "43, 108, 196",
+					"synonyms": [
+						"Denim"
+					]
+				},
+				{
+					"value": "239, 205, 184",
+					"synonyms": [
+						"Desert Sand"
+					]
+				},
+				{
+					"value": "110, 81, 96",
+					"synonyms": [
+						"Eggplant"
+					]
+				},
+				{
+					"value": "206, 255, 29",
+					"synonyms": [
+						"Electric Lime"
+					]
+				},
+				{
+					"value": "113, 188, 120",
+					"synonyms": [
+						"Fern"
+					]
+				},
+				{
+					"value": "109, 174, 129",
+					"synonyms": [
+						"Forest Green"
+					]
+				},
+				{
+					"value": "195, 100, 197",
+					"synonyms": [
+						"Fuchsia"
+					]
+				},
+				{
+					"value": "204, 102, 102",
+					"synonyms": [
+						"Fuzzy Wuzzy"
+					]
+				},
+				{
+					"value": "231, 198, 151",
+					"synonyms": [
+						"Gold"
+					]
+				},
+				{
+					"value": "252, 217, 117",
+					"synonyms": [
+						"Goldenrod"
+					]
+				},
+				{
+					"value": "168, 228, 160",
+					"synonyms": [
+						"Granny Smith Apple"
+					]
+				},
+				{
+					"value": "149, 145, 140",
+					"synonyms": [
+						"Gray"
+					]
+				},
+				{
+					"value": "28, 172, 120",
+					"synonyms": [
+						"Green"
+					]
+				},
+				{
+					"value": "17, 100, 180",
+					"synonyms": [
+						"Green Blue"
+					]
+				},
+				{
+					"value": "240, 232, 145",
+					"synonyms": [
+						"Green Yellow"
+					]
+				},
+				{
+					"value": "255, 29, 206",
+					"synonyms": [
+						"Hot Magenta"
+					]
+				},
+				{
+					"value": "178, 236, 93",
+					"synonyms": [
+						"Inchworm"
+					]
+				},
+				{
+					"value": "93, 118, 203",
+					"synonyms": [
+						"Indigo"
+					]
+				},
+				{
+					"value": "202, 55, 103",
+					"synonyms": [
+						"Jazzberry Jam"
+					]
+				},
+				{
+					"value": "59, 176, 143",
+					"synonyms": [
+						"Jungle Green"
+					]
+				},
+				{
+					"value": "254, 254, 34",
+					"synonyms": [
+						"Laser Lemon"
+					]
+				},
+				{
+					"value": "252, 180, 213",
+					"synonyms": [
+						"Lavender"
+					]
+				},
+				{
+					"value": "255, 244, 79",
+					"synonyms": [
+						"Lemon Yellow"
+					]
+				},
+				{
+					"value": "255, 189, 136",
+					"synonyms": [
+						"Macaroni and Cheese"
+					]
+				},
+				{
+					"value": "246, 100, 175",
+					"synonyms": [
+						"Magenta"
+					]
+				},
+				{
+					"value": "170, 240, 209",
+					"synonyms": [
+						"Magic Mint"
+					]
+				},
+				{
+					"value": "205, 74, 76",
+					"synonyms": [
+						"Mahogany"
+					]
+				},
+				{
+					"value": "237, 209, 156",
+					"synonyms": [
+						"Maize"
+					]
+				},
+				{
+					"value": "151, 154, 170",
+					"synonyms": [
+						"Manatee"
+					]
+				},
+				{
+					"value": "255, 130, 67",
+					"synonyms": [
+						"Mango Tango"
+					]
+				},
+				{
+					"value": "200, 56, 90",
+					"synonyms": [
+						"Maroon"
+					]
+				},
+				{
+					"value": "239, 152, 170",
+					"synonyms": [
+						"Mauvelous"
+					]
+				},
+				{
+					"value": "253, 188, 180",
+					"synonyms": [
+						"Melon"
+					]
+				},
+				{
+					"value": "26, 72, 118",
+					"synonyms": [
+						"Midnight Blue"
+					]
+				},
+				{
+					"value": "48, 186, 143",
+					"synonyms": [
+						"Mountain Meadow"
+					]
+				},
+				{
+					"value": "197, 75, 140",
+					"synonyms": [
+						"Mulberry"
+					]
+				},
+				{
+					"value": "25, 116, 210",
+					"synonyms": [
+						"Navy Blue"
+					]
+				},
+				{
+					"value": "255, 163, 67",
+					"synonyms": [
+						"Neon Carrot"
+					]
+				},
+				{
+					"value": "186, 184, 108",
+					"synonyms": [
+						"Olive Green"
+					]
+				},
+				{
+					"value": "255, 117, 56",
+					"synonyms": [
+						"Orange"
+					]
+				},
+				{
+					"value": "255, 43, 43",
+					"synonyms": [
+						"Orange Red"
+					]
+				},
+				{
+					"value": "248, 213, 104",
+					"synonyms": [
+						"Orange Yellow"
+					]
+				},
+				{
+					"value": "230, 168, 215",
+					"synonyms": [
+						"Orchid"
+					]
+				},
+				{
+					"value": "65, 74, 76",
+					"synonyms": [
+						"Outer Space"
+					]
+				},
+				{
+					"value": "255, 110, 74",
+					"synonyms": [
+						"Outrageous Orange"
+					]
+				},
+				{
+					"value": "28, 169, 201",
+					"synonyms": [
+						"Pacific Blue"
+					]
+				},
+				{
+					"value": "255, 207, 171",
+					"synonyms": [
+						"Peach"
+					]
+				},
+				{
+					"value": "197, 208, 230",
+					"synonyms": [
+						"Periwinkle"
+					]
+				},
+				{
+					"value": "253, 221, 230",
+					"synonyms": [
+						"Piggy Pink"
+					]
+				},
+				{
+					"value": "21, 128, 120",
+					"synonyms": [
+						"Pine Green"
+					]
+				},
+				{
+					"value": "252, 116, 253",
+					"synonyms": [
+						"Pink Flamingo"
+					]
+				},
+				{
+					"value": "247, 143, 167",
+					"synonyms": [
+						"Pink Sherbet"
+					]
+				},
+				{
+					"value": "142, 69, 133",
+					"synonyms": [
+						"Plum"
+					]
+				},
+				{
+					"value": "116, 66, 200",
+					"synonyms": [
+						"Purple Heart"
+					]
+				},
+				{
+					"value": "157, 129, 186",
+					"synonyms": [
+						"Purple Mountain's Majesty"
+					]
+				},
+				{
+					"value": "254, 78, 218",
+					"synonyms": [
+						"Purple Pizzazz"
+					]
+				},
+				{
+					"value": "255, 73, 108",
+					"synonyms": [
+						"Radical Red"
+					]
+				},
+				{
+					"value": "214, 138, 89",
+					"synonyms": [
+						"Raw Sienna"
+					]
+				},
+				{
+					"value": "113, 75, 35",
+					"synonyms": [
+						"Raw Umber"
+					]
+				},
+				{
+					"value": "255, 72, 208",
+					"synonyms": [
+						"Razzle Dazzle Rose"
+					]
+				},
+				{
+					"value": "227, 37, 107",
+					"synonyms": [
+						"Razzmatazz"
+					]
+				},
+				{
+					"value": "238,32 ,77 ",
+					"synonyms": [
+						"Red"
+					]
+				},
+				{
+					"value": "255, 83, 73",
+					"synonyms": [
+						"Red Orange"
+					]
+				},
+				{
+					"value": "192, 68, 143",
+					"synonyms": [
+						"Red Violet"
+					]
+				},
+				{
+					"value": "31, 206, 203",
+					"synonyms": [
+						"Robin's Egg Blue"
+					]
+				},
+				{
+					"value": "120, 81, 169",
+					"synonyms": [
+						"Royal Purple"
+					]
+				},
+				{
+					"value": "255, 155, 170",
+					"synonyms": [
+						"Salmon"
+					]
+				},
+				{
+					"value": "252, 40, 71",
+					"synonyms": [
+						"Scarlet"
+					]
+				},
+				{
+					"value": "118, 255, 122",
+					"synonyms": [
+						"Screamin' Green"
+					]
+				},
+				{
+					"value": "159, 226, 191",
+					"synonyms": [
+						"Sea Green"
+					]
+				},
+				{
+					"value": "165, 105, 79",
+					"synonyms": [
+						"Sepia"
+					]
+				},
+				{
+					"value": "138, 121, 93",
+					"synonyms": [
+						"Shadow"
+					]
+				},
+				{
+					"value": "69, 206, 162",
+					"synonyms": [
+						"Shamrock"
+					]
+				},
+				{
+					"value": "251, 126, 253",
+					"synonyms": [
+						"Shocking Pink"
+					]
+				},
+				{
+					"value": "205, 197, 194",
+					"synonyms": [
+						"Silver"
+					]
+				},
+				{
+					"value": "128, 218, 235",
+					"synonyms": [
+						"Sky Blue"
+					]
+				},
+				{
+					"value": "236, 234, 190",
+					"synonyms": [
+						"Spring Green"
+					]
+				},
+				{
+					"value": "255, 207, 72",
+					"synonyms": [
+						"Sunglow"
+					]
+				},
+				{
+					"value": "253, 94, 83",
+					"synonyms": [
+						"Sunset Orange"
+					]
+				},
+				{
+					"value": "250, 167, 108",
+					"synonyms": [
+						"Tan"
+					]
+				},
+				{
+					"value": "24, 167, 181",
+					"synonyms": [
+						"Teal Blue"
+					]
+				},
+				{
+					"value": "235, 199, 223",
+					"synonyms": [
+						"Thistle"
+					]
+				},
+				{
+					"value": "252, 137, 172",
+					"synonyms": [
+						"Tickle Me Pink"
+					]
+				},
+				{
+					"value": "219, 215, 210",
+					"synonyms": [
+						"Timberwolf"
+					]
+				},
+				{
+					"value": "23, 128, 109",
+					"synonyms": [
+						"Tropical Rain Forest"
+					]
+				},
+				{
+					"value": "222, 170, 136",
+					"synonyms": [
+						"Tumbleweed"
+					]
+				},
+				{
+					"value": "119, 221, 231",
+					"synonyms": [
+						"Turquoise Blue"
+					]
+				},
+				{
+					"value": "255, 255, 102",
+					"synonyms": [
+						"Unmellow Yellow"
+					]
+				},
+				{
+					"value": "146, 110, 174",
+					"synonyms": [
+						"Violet (Purple"
+					]
+				},
+				{
+					"value": "50, 74, 178",
+					"synonyms": [
+						"Violet Blue"
+					]
+				},
+				{
+					"value": "247, 83, 148",
+					"synonyms": [
+						"Violet Red"
+					]
+				},
+				{
+					"value": "255, 160, 137",
+					"synonyms": [
+						"Vivid Tangerine"
+					]
+				},
+				{
+					"value": "143, 80, 157",
+					"synonyms": [
+						"Vivid Violet"
+					]
+				},
+				{
+					"value": "255, 255, 255",
+					"synonyms": [
+						"White"
+					]
+				},
+				{
+					"value": "162, 173, 208",
+					"synonyms": [
+						"Wild Blue Yonder"
+					]
+				},
+				{
+					"value": "255, 67, 164",
+					"synonyms": [
+						"Wild Strawberry"
+					]
+				},
+				{
+					"value": "252, 108, 133",
+					"synonyms": [
+						"Wild Watermelon"
+					]
+				},
+				{
+					"value": "205, 164, 222",
+					"synonyms": [
+						"Wisteria"
+					]
+				},
+				{
+					"value": "252, 232, 131",
+					"synonyms": [
+						"Yellow"
+					]
+				},
+				{
+					"value": "197, 227, 132",
+					"synonyms": [
+						"Yellow Green"
+					]
+				},
+				{
+					"value": "255, 174, 66",
+					"synonyms": [
+						"Yellow Orange"
+					]
+				}
+			]
 		}
 	],
 	"intents": [

--- a/dialogTemplate/it.json
+++ b/dialogTemplate/it.json
@@ -17508,6 +17508,812 @@
 					"value": "zucchero"
 				}
 			]
+		},
+		{
+			"name": "Alice/Colours",
+			"matchingStrictness": null,
+			"automaticallyExtensible": true,
+			"useSynonyms": true,
+			"values": [
+				{
+					"value": "239, 222, 205",
+					"synonyms": [
+						"Almond"
+					]
+				},
+				{
+					"value": "205, 149, 117",
+					"synonyms": [
+						"Antique Brass"
+					]
+				},
+				{
+					"value": "253, 217, 181",
+					"synonyms": [
+						"Apricot"
+					]
+				},
+				{
+					"value": "120, 219, 226",
+					"synonyms": [
+						"Aquamarine"
+					]
+				},
+				{
+					"value": "135, 169, 107",
+					"synonyms": [
+						"Asparagus"
+					]
+				},
+				{
+					"value": "255, 164, 116",
+					"synonyms": [
+						"Atomic Tangerine"
+					]
+				},
+				{
+					"value": "250, 231, 181",
+					"synonyms": [
+						"Banana Mania"
+					]
+				},
+				{
+					"value": "159, 129, 112",
+					"synonyms": [
+						"Beaver"
+					]
+				},
+				{
+					"value": "253, 124, 110",
+					"synonyms": [
+						"Bittersweet"
+					]
+				},
+				{
+					"value": "0,0,0",
+					"synonyms": [
+						"Black"
+					]
+				},
+				{
+					"value": "172, 229, 238",
+					"synonyms": [
+						"Blizzard Blue"
+					]
+				},
+				{
+					"value": "31, 117, 254",
+					"synonyms": [
+						"Blue"
+					]
+				},
+				{
+					"value": "162, 162, 208",
+					"synonyms": [
+						"Blue Bell"
+					]
+				},
+				{
+					"value": "102, 153, 204",
+					"synonyms": [
+						"Blue Gray"
+					]
+				},
+				{
+					"value": "13, 152, 186",
+					"synonyms": [
+						"Blue Green"
+					]
+				},
+				{
+					"value": "115, 102, 189",
+					"synonyms": [
+						"Blue Violet"
+					]
+				},
+				{
+					"value": "222, 93, 131",
+					"synonyms": [
+						"Blush"
+					]
+				},
+				{
+					"value": "203, 65, 84",
+					"synonyms": [
+						"Brick Red"
+					]
+				},
+				{
+					"value": "180, 103, 77",
+					"synonyms": [
+						"Brown"
+					]
+				},
+				{
+					"value": "255, 127, 73",
+					"synonyms": [
+						"Burnt Orange"
+					]
+				},
+				{
+					"value": "234, 126, 93",
+					"synonyms": [
+						"Burnt Sienna"
+					]
+				},
+				{
+					"value": "176, 183, 198",
+					"synonyms": [
+						"Cadet Blue"
+					]
+				},
+				{
+					"value": "255, 255, 153",
+					"synonyms": [
+						"Canary"
+					]
+				},
+				{
+					"value": "28, 211, 162",
+					"synonyms": [
+						"Caribbean Green"
+					]
+				},
+				{
+					"value": "255, 170, 204",
+					"synonyms": [
+						"Carnation Pink"
+					]
+				},
+				{
+					"value": "221, 68, 146",
+					"synonyms": [
+						"Cerise"
+					]
+				},
+				{
+					"value": "29, 172, 214",
+					"synonyms": [
+						"Cerulean"
+					]
+				},
+				{
+					"value": "188, 93, 88",
+					"synonyms": [
+						"Chestnut"
+					]
+				},
+				{
+					"value": "221, 148, 117",
+					"synonyms": [
+						"Copper"
+					]
+				},
+				{
+					"value": "154, 206, 235",
+					"synonyms": [
+						"Cornflower"
+					]
+				},
+				{
+					"value": "255, 188, 217",
+					"synonyms": [
+						"Cotton Candy"
+					]
+				},
+				{
+					"value": "253, 219, 109",
+					"synonyms": [
+						"Dandelion"
+					]
+				},
+				{
+					"value": "43, 108, 196",
+					"synonyms": [
+						"Denim"
+					]
+				},
+				{
+					"value": "239, 205, 184",
+					"synonyms": [
+						"Desert Sand"
+					]
+				},
+				{
+					"value": "110, 81, 96",
+					"synonyms": [
+						"Eggplant"
+					]
+				},
+				{
+					"value": "206, 255, 29",
+					"synonyms": [
+						"Electric Lime"
+					]
+				},
+				{
+					"value": "113, 188, 120",
+					"synonyms": [
+						"Fern"
+					]
+				},
+				{
+					"value": "109, 174, 129",
+					"synonyms": [
+						"Forest Green"
+					]
+				},
+				{
+					"value": "195, 100, 197",
+					"synonyms": [
+						"Fuchsia"
+					]
+				},
+				{
+					"value": "204, 102, 102",
+					"synonyms": [
+						"Fuzzy Wuzzy"
+					]
+				},
+				{
+					"value": "231, 198, 151",
+					"synonyms": [
+						"Gold"
+					]
+				},
+				{
+					"value": "252, 217, 117",
+					"synonyms": [
+						"Goldenrod"
+					]
+				},
+				{
+					"value": "168, 228, 160",
+					"synonyms": [
+						"Granny Smith Apple"
+					]
+				},
+				{
+					"value": "149, 145, 140",
+					"synonyms": [
+						"Gray"
+					]
+				},
+				{
+					"value": "28, 172, 120",
+					"synonyms": [
+						"Green"
+					]
+				},
+				{
+					"value": "17, 100, 180",
+					"synonyms": [
+						"Green Blue"
+					]
+				},
+				{
+					"value": "240, 232, 145",
+					"synonyms": [
+						"Green Yellow"
+					]
+				},
+				{
+					"value": "255, 29, 206",
+					"synonyms": [
+						"Hot Magenta"
+					]
+				},
+				{
+					"value": "178, 236, 93",
+					"synonyms": [
+						"Inchworm"
+					]
+				},
+				{
+					"value": "93, 118, 203",
+					"synonyms": [
+						"Indigo"
+					]
+				},
+				{
+					"value": "202, 55, 103",
+					"synonyms": [
+						"Jazzberry Jam"
+					]
+				},
+				{
+					"value": "59, 176, 143",
+					"synonyms": [
+						"Jungle Green"
+					]
+				},
+				{
+					"value": "254, 254, 34",
+					"synonyms": [
+						"Laser Lemon"
+					]
+				},
+				{
+					"value": "252, 180, 213",
+					"synonyms": [
+						"Lavender"
+					]
+				},
+				{
+					"value": "255, 244, 79",
+					"synonyms": [
+						"Lemon Yellow"
+					]
+				},
+				{
+					"value": "255, 189, 136",
+					"synonyms": [
+						"Macaroni and Cheese"
+					]
+				},
+				{
+					"value": "246, 100, 175",
+					"synonyms": [
+						"Magenta"
+					]
+				},
+				{
+					"value": "170, 240, 209",
+					"synonyms": [
+						"Magic Mint"
+					]
+				},
+				{
+					"value": "205, 74, 76",
+					"synonyms": [
+						"Mahogany"
+					]
+				},
+				{
+					"value": "237, 209, 156",
+					"synonyms": [
+						"Maize"
+					]
+				},
+				{
+					"value": "151, 154, 170",
+					"synonyms": [
+						"Manatee"
+					]
+				},
+				{
+					"value": "255, 130, 67",
+					"synonyms": [
+						"Mango Tango"
+					]
+				},
+				{
+					"value": "200, 56, 90",
+					"synonyms": [
+						"Maroon"
+					]
+				},
+				{
+					"value": "239, 152, 170",
+					"synonyms": [
+						"Mauvelous"
+					]
+				},
+				{
+					"value": "253, 188, 180",
+					"synonyms": [
+						"Melon"
+					]
+				},
+				{
+					"value": "26, 72, 118",
+					"synonyms": [
+						"Midnight Blue"
+					]
+				},
+				{
+					"value": "48, 186, 143",
+					"synonyms": [
+						"Mountain Meadow"
+					]
+				},
+				{
+					"value": "197, 75, 140",
+					"synonyms": [
+						"Mulberry"
+					]
+				},
+				{
+					"value": "25, 116, 210",
+					"synonyms": [
+						"Navy Blue"
+					]
+				},
+				{
+					"value": "255, 163, 67",
+					"synonyms": [
+						"Neon Carrot"
+					]
+				},
+				{
+					"value": "186, 184, 108",
+					"synonyms": [
+						"Olive Green"
+					]
+				},
+				{
+					"value": "255, 117, 56",
+					"synonyms": [
+						"Orange"
+					]
+				},
+				{
+					"value": "255, 43, 43",
+					"synonyms": [
+						"Orange Red"
+					]
+				},
+				{
+					"value": "248, 213, 104",
+					"synonyms": [
+						"Orange Yellow"
+					]
+				},
+				{
+					"value": "230, 168, 215",
+					"synonyms": [
+						"Orchid"
+					]
+				},
+				{
+					"value": "65, 74, 76",
+					"synonyms": [
+						"Outer Space"
+					]
+				},
+				{
+					"value": "255, 110, 74",
+					"synonyms": [
+						"Outrageous Orange"
+					]
+				},
+				{
+					"value": "28, 169, 201",
+					"synonyms": [
+						"Pacific Blue"
+					]
+				},
+				{
+					"value": "255, 207, 171",
+					"synonyms": [
+						"Peach"
+					]
+				},
+				{
+					"value": "197, 208, 230",
+					"synonyms": [
+						"Periwinkle"
+					]
+				},
+				{
+					"value": "253, 221, 230",
+					"synonyms": [
+						"Piggy Pink"
+					]
+				},
+				{
+					"value": "21, 128, 120",
+					"synonyms": [
+						"Pine Green"
+					]
+				},
+				{
+					"value": "252, 116, 253",
+					"synonyms": [
+						"Pink Flamingo"
+					]
+				},
+				{
+					"value": "247, 143, 167",
+					"synonyms": [
+						"Pink Sherbet"
+					]
+				},
+				{
+					"value": "142, 69, 133",
+					"synonyms": [
+						"Plum"
+					]
+				},
+				{
+					"value": "116, 66, 200",
+					"synonyms": [
+						"Purple Heart"
+					]
+				},
+				{
+					"value": "157, 129, 186",
+					"synonyms": [
+						"Purple Mountain's Majesty"
+					]
+				},
+				{
+					"value": "254, 78, 218",
+					"synonyms": [
+						"Purple Pizzazz"
+					]
+				},
+				{
+					"value": "255, 73, 108",
+					"synonyms": [
+						"Radical Red"
+					]
+				},
+				{
+					"value": "214, 138, 89",
+					"synonyms": [
+						"Raw Sienna"
+					]
+				},
+				{
+					"value": "113, 75, 35",
+					"synonyms": [
+						"Raw Umber"
+					]
+				},
+				{
+					"value": "255, 72, 208",
+					"synonyms": [
+						"Razzle Dazzle Rose"
+					]
+				},
+				{
+					"value": "227, 37, 107",
+					"synonyms": [
+						"Razzmatazz"
+					]
+				},
+				{
+					"value": "238,32 ,77 ",
+					"synonyms": [
+						"Red"
+					]
+				},
+				{
+					"value": "255, 83, 73",
+					"synonyms": [
+						"Red Orange"
+					]
+				},
+				{
+					"value": "192, 68, 143",
+					"synonyms": [
+						"Red Violet"
+					]
+				},
+				{
+					"value": "31, 206, 203",
+					"synonyms": [
+						"Robin's Egg Blue"
+					]
+				},
+				{
+					"value": "120, 81, 169",
+					"synonyms": [
+						"Royal Purple"
+					]
+				},
+				{
+					"value": "255, 155, 170",
+					"synonyms": [
+						"Salmon"
+					]
+				},
+				{
+					"value": "252, 40, 71",
+					"synonyms": [
+						"Scarlet"
+					]
+				},
+				{
+					"value": "118, 255, 122",
+					"synonyms": [
+						"Screamin' Green"
+					]
+				},
+				{
+					"value": "159, 226, 191",
+					"synonyms": [
+						"Sea Green"
+					]
+				},
+				{
+					"value": "165, 105, 79",
+					"synonyms": [
+						"Sepia"
+					]
+				},
+				{
+					"value": "138, 121, 93",
+					"synonyms": [
+						"Shadow"
+					]
+				},
+				{
+					"value": "69, 206, 162",
+					"synonyms": [
+						"Shamrock"
+					]
+				},
+				{
+					"value": "251, 126, 253",
+					"synonyms": [
+						"Shocking Pink"
+					]
+				},
+				{
+					"value": "205, 197, 194",
+					"synonyms": [
+						"Silver"
+					]
+				},
+				{
+					"value": "128, 218, 235",
+					"synonyms": [
+						"Sky Blue"
+					]
+				},
+				{
+					"value": "236, 234, 190",
+					"synonyms": [
+						"Spring Green"
+					]
+				},
+				{
+					"value": "255, 207, 72",
+					"synonyms": [
+						"Sunglow"
+					]
+				},
+				{
+					"value": "253, 94, 83",
+					"synonyms": [
+						"Sunset Orange"
+					]
+				},
+				{
+					"value": "250, 167, 108",
+					"synonyms": [
+						"Tan"
+					]
+				},
+				{
+					"value": "24, 167, 181",
+					"synonyms": [
+						"Teal Blue"
+					]
+				},
+				{
+					"value": "235, 199, 223",
+					"synonyms": [
+						"Thistle"
+					]
+				},
+				{
+					"value": "252, 137, 172",
+					"synonyms": [
+						"Tickle Me Pink"
+					]
+				},
+				{
+					"value": "219, 215, 210",
+					"synonyms": [
+						"Timberwolf"
+					]
+				},
+				{
+					"value": "23, 128, 109",
+					"synonyms": [
+						"Tropical Rain Forest"
+					]
+				},
+				{
+					"value": "222, 170, 136",
+					"synonyms": [
+						"Tumbleweed"
+					]
+				},
+				{
+					"value": "119, 221, 231",
+					"synonyms": [
+						"Turquoise Blue"
+					]
+				},
+				{
+					"value": "255, 255, 102",
+					"synonyms": [
+						"Unmellow Yellow"
+					]
+				},
+				{
+					"value": "146, 110, 174",
+					"synonyms": [
+						"Violet (Purple"
+					]
+				},
+				{
+					"value": "50, 74, 178",
+					"synonyms": [
+						"Violet Blue"
+					]
+				},
+				{
+					"value": "247, 83, 148",
+					"synonyms": [
+						"Violet Red"
+					]
+				},
+				{
+					"value": "255, 160, 137",
+					"synonyms": [
+						"Vivid Tangerine"
+					]
+				},
+				{
+					"value": "143, 80, 157",
+					"synonyms": [
+						"Vivid Violet"
+					]
+				},
+				{
+					"value": "255, 255, 255",
+					"synonyms": [
+						"White"
+					]
+				},
+				{
+					"value": "162, 173, 208",
+					"synonyms": [
+						"Wild Blue Yonder"
+					]
+				},
+				{
+					"value": "255, 67, 164",
+					"synonyms": [
+						"Wild Strawberry"
+					]
+				},
+				{
+					"value": "252, 108, 133",
+					"synonyms": [
+						"Wild Watermelon"
+					]
+				},
+				{
+					"value": "205, 164, 222",
+					"synonyms": [
+						"Wisteria"
+					]
+				},
+				{
+					"value": "252, 232, 131",
+					"synonyms": [
+						"Yellow"
+					]
+				},
+				{
+					"value": "197, 227, 132",
+					"synonyms": [
+						"Yellow Green"
+					]
+				},
+				{
+					"value": "255, 174, 66",
+					"synonyms": [
+						"Yellow Orange"
+					]
+				}
+			]
 		}
 	],
 	"intents": [


### PR DESCRIPTION
Will this be of benefit to Alice down the track ? EG: used for changing light colours

Idea being synonym is what will be triggered from user speech (slotRawValue) and if needed skill maker can use the slotValue to send a RGB code ? 

if not something you want let me know and i'll add it to the skill directly : )

PS: feel free to change colours to colors if that's preferred 